### PR TITLE
Feat/steam-auth-login-flow

### DIFF
--- a/apps/client/project.godot
+++ b/apps/client/project.godot
@@ -11,12 +11,14 @@ config_version=5
 [application]
 
 config/name="red-hat"
+run/main_scene="res://scenes/ui/steam_auth_test.tscn"
 config/features=PackedStringArray("4.6", "GL Compatibility")
 config/icon="res://icon.svg"
 
 [autoload]
 
 GameState="*res://scripts/game/game_state.gd"
+ApiClient="*res://scripts/network/api_client.gd"
 
 [physics]
 

--- a/apps/client/scenes/ui/steam_auth_test.gd
+++ b/apps/client/scenes/ui/steam_auth_test.gd
@@ -1,0 +1,40 @@
+## steam_auth_test.gd
+## Manual test scene for the Steam authentication flow.
+## Run this scene with F5 and press the button to verify auth end-to-end.
+##
+## Authority: client
+## AutoLoad: no
+extends Control
+
+@onready var _status_label: Label = $VBoxContainer/StatusLabel
+@onready var _auth_button: Button = $VBoxContainer/AuthButton
+
+var _steam_auth: Node = null
+
+
+func _ready() -> void:
+	_steam_auth = preload("res://scripts/network/steam_auth.gd").new()
+	add_child(_steam_auth)
+	_steam_auth.auth_succeeded.connect(_on_auth_succeeded)
+	_steam_auth.auth_failed.connect(_on_auth_failed)
+	_auth_button.pressed.connect(_on_auth_button_pressed)
+	print("[SteamAuthTest] Ready — click the button to begin Steam authentication")
+
+
+func _on_auth_button_pressed() -> void:
+	_status_label.text = "인증 중..."
+	_auth_button.disabled = true
+	print("[SteamAuthTest] Button pressed — starting authentication")
+	_steam_auth.authenticate()
+
+
+func _on_auth_succeeded() -> void:
+	_status_label.text = "✅ 인증 성공!\n이름: %s\nSteam ID: %s" % [GameState.player_name, GameState.steam_id]
+	_auth_button.disabled = false
+	print("[SteamAuthTest] SUCCESS — player_name='%s'  steam_id=%s" % [GameState.player_name, GameState.steam_id])
+
+
+func _on_auth_failed(reason: String) -> void:
+	_status_label.text = "❌ 인증 실패\n" + reason
+	_auth_button.disabled = false
+	push_warning("[SteamAuthTest] FAILED — " + reason)

--- a/apps/client/scenes/ui/steam_auth_test.gd.uid
+++ b/apps/client/scenes/ui/steam_auth_test.gd.uid
@@ -1,0 +1,1 @@
+uid://d4lq6jivj637g

--- a/apps/client/scenes/ui/steam_auth_test.tscn
+++ b/apps/client/scenes/ui/steam_auth_test.tscn
@@ -1,0 +1,33 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scenes/ui/steam_auth_test.gd" id="1"]
+
+[node name="SteamAuthTest" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -150.0
+offset_top = -80.0
+offset_right = 150.0
+offset_bottom = 80.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 16
+
+[node name="StatusLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Steam 인증 대기 중..."
+horizontal_alignment = 1
+autowrap_mode = 2
+
+[node name="AuthButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Steam 로그인"

--- a/apps/client/scripts/game/game_state.gd
+++ b/apps/client/scripts/game/game_state.gd
@@ -28,6 +28,18 @@ signal authenticated
 signal match_found(match_id: String)
 
 
+func _ready() -> void:
+	if not Engine.has_singleton("Steam"):
+		push_error("[GameState] Steam singleton not found — make sure you are using the GodotSteam editor")
+		return
+	var steam: Object = Engine.get_singleton("Steam")
+	var init: Dictionary = steam.steamInitEx()
+	if init["status"] != 0:
+		push_error("[GameState] Steam failed to initialize: " + str(init["verbal"]))
+	else:
+		print("[GameState] Steam initialized — app_id: %d, verbal: %s" % [steam.getAppID(), init["verbal"]])
+
+
 ## Returns true if the player holds a valid JWT (i.e. is logged in).
 func is_authenticated() -> bool:
 	return jwt != ""

--- a/apps/client/scripts/network/steam_auth.gd
+++ b/apps/client/scripts/network/steam_auth.gd
@@ -12,10 +12,92 @@ signal auth_succeeded
 ## Emitted when authentication fails for any reason.
 signal auth_failed(reason: String)
 
+var _pending_ticket_handle: int = 0
+
 
 ## Begins the Steam authentication flow.
 ## 1. Requests an auth ticket from GodotSteam.
 ## 2. POSTs the ticket to /auth/steam.
 ## 3. Stores the returned JWT in GameState.
 func authenticate() -> void:
-	pass
+	if not Engine.has_singleton("Steam"):
+		push_error("[SteamAuth] Steam singleton not found — make sure you are using the GodotSteam editor")
+		auth_failed.emit("Steam singleton not found")
+		return
+
+	var steam: Object = Engine.get_singleton("Steam")
+
+	if not steam.isSteamRunning():
+		push_warning("[SteamAuth] Steam client is not running")
+		auth_failed.emit("Steam client is not running")
+		return
+
+	# getSteamID() returns 0 if Steam is running but not logged in / not fully initialized
+	var steam_id_check: int = steam.getSteamID()
+	print("[SteamAuth] Steam state — isSteamRunning: true, getSteamID: %d, personaName: '%s'" % [
+		steam_id_check, steam.getPersonaName()
+	])
+
+	if steam_id_check == 0:
+		push_warning("[SteamAuth] getSteamID() returned 0 — Steam is running but not fully initialized or not logged in")
+		auth_failed.emit("Steam not fully initialized (getSteamID = 0)")
+		return
+
+	steam.get_ticket_for_web_api.connect(_on_ticket_received, CONNECT_ONE_SHOT)
+	# Pass empty string as identity — using a custom identity requires server-side registration
+	_pending_ticket_handle = steam.getAuthTicketForWebApi("")
+	print("[SteamAuth] Requesting auth ticket (handle: %d)" % _pending_ticket_handle)
+
+	# handle 0 = k_HAuthTicketInvalid — Steam rejected the request immediately
+	if _pending_ticket_handle == 0:
+		steam.get_ticket_for_web_api.disconnect(_on_ticket_received)
+		push_warning("[SteamAuth] getAuthTicketForWebApi returned invalid handle (0) — is steam_appid.txt present and Steam running?")
+		auth_failed.emit("Failed to request auth ticket (invalid handle)")
+
+
+# GodotSteam signal: get_ticket_for_web_api(auth_ticket, result, ticket_size, ticket_buffer)
+func _on_ticket_received(auth_ticket: int, result: int, _ticket_size: int, ticket: PackedByteArray) -> void:
+	# k_EResultOK = 1
+	if result != 1:
+		push_warning("[SteamAuth] Ticket generation failed (result: %d)" % result)
+		auth_failed.emit("Ticket generation failed (result: %d)" % result)
+		return
+
+	print("[SteamAuth] Ticket received — handle: %d, size: %d bytes" % [auth_ticket, ticket.size()])
+
+	var steam: Object = Engine.get_singleton("Steam")
+	var steam_id: String = str(steam.getSteamID())
+	var ticket_hex: String = _bytes_to_hex(ticket)
+
+	var response: Dictionary = await ApiClient.post("/auth/steam", {
+		"ticket": ticket_hex,
+		"steam_id": steam_id,
+	})
+
+	# Always cancel the ticket after use regardless of result
+	steam.cancelAuthTicket(auth_ticket)
+
+	if response.has("error"):
+		push_warning("[SteamAuth] Auth failed: " + str(response["error"]))
+		auth_failed.emit(str(response["error"]))
+		return
+
+	if not response.has("token"):
+		push_warning("[SteamAuth] Server response missing 'token' field")
+		auth_failed.emit("Invalid server response")
+		return
+
+	GameState.jwt = response["token"]
+	GameState.steam_id = steam_id
+	GameState.player_name = steam.getPersonaName()
+	GameState.authenticated.emit()
+
+	print("[SteamAuth] Authenticated! name='%s'  steam_id=%s" % [GameState.player_name, GameState.steam_id])
+	auth_succeeded.emit()
+
+
+func _bytes_to_hex(bytes: PackedByteArray) -> String:
+	var hex: String = ""
+	for b: int in bytes:
+		hex += "%02x" % b
+	return hex


### PR DESCRIPTION
Related to #5

## 무엇을 왜 변경했나요?
클라이언트 Steam 인증 흐름을 구현했습니다.
`steamInitEx()` 미호출로 `getSteamID()`가 0을 반환하던 문제를 함께 수정했습니다.

- `GameState._ready()`에서 `Steam.steamInitEx()` 호출 추가
- Steam 인증 흐름 수동 테스트용 씬(`steam_auth_test.tscn`) 추가
- 실패 케이스(Steam 미실행, getSteamID=0, 티켓 발급 실패) 에러 메시지 처리

완료 기준 현황:
- [x] Steam 티켓 발급 성공 로그 Output 패널 확인
- [ ] /auth/steam 응답으로 JWT 수신 확인 — 백엔드 준비 후 검증 예정
- [x] 인증 실패 시 에러 메시지 Output 패널 확인

## 메모 (선택)
`/auth/steam` 엔드포인트 준비되면 end-to-end 테스트 후 이슈 close 예정.
백엔드 작업은 별도 이슈로 추적.